### PR TITLE
Optimize transitive vector scaling

### DIFF
--- a/math/vector3.cpp
+++ b/math/vector3.cpp
@@ -29,7 +29,9 @@ Vector3 operator*(const Vector3& left, float right) noexcept
 
 Vector3 operator*(float left, const Vector3& right) noexcept
 {
-    return right * left;
+    auto result(right);
+    result *= left;
+    return result;
 }
 
 Vector3 operator/(const Vector3& left, float right) noexcept

--- a/math/vector3_benchmark.cpp
+++ b/math/vector3_benchmark.cpp
@@ -32,7 +32,7 @@ void benchmarkVector3OperatorMinus(benchmark::State& state)
     }
 }
 
-void benchmarkVector3OperatorMultiply(benchmark::State& state)
+void benchmarkVector3OperatorMultiplyScaleOnRight(benchmark::State& state)
 {
     Vector3 randLeft(RandomGenerator::generateRandomVector3());
     float scale = RandomGenerator::generateRandomFloat();
@@ -40,6 +40,17 @@ void benchmarkVector3OperatorMultiply(benchmark::State& state)
     for (auto s : state)
     {
         const auto result(randLeft * scale);
+    }
+}
+
+void benchmarkVector3OperatorMultiplyScaleOnLeft(benchmark::State& state)
+{
+    Vector3 randRight(RandomGenerator::generateRandomVector3());
+    float scale = RandomGenerator::generateRandomFloat();
+
+    for (auto s : state)
+    {
+        const auto result(scale * randRight);
     }
 }
 
@@ -126,7 +137,10 @@ BENCHMARK(benchmarkVector3OperatorPlus);
 BENCHMARK(benchmarkVector3OperatorMinus);
 
 // NOLINTNEXTLINE
-BENCHMARK(benchmarkVector3OperatorMultiply);
+BENCHMARK(benchmarkVector3OperatorMultiplyScaleOnRight);
+
+// NOLINTNEXTLINE
+BENCHMARK(benchmarkVector3OperatorMultiplyScaleOnLeft);
 
 // NOLINTNEXTLINE
 BENCHMARK(benchmarkVector3OperatorDivide);


### PR DESCRIPTION
When implementing #8, benchmarking revealed transitive operations are faster if implemented without reusing operators. Apply this to Vector3 scale operator