### PR TITLE
Enable warnings and C++17 compiler settings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,4 @@
-Checks: '*, -android*, -fuchsia*, -google*, -llvm*, -modernize-use-trailing-return-type'
+Checks: '*, -abseil*, -android*, -cppcoreguidelines-avoid-magic-numbers, -fuchsia*, -google*, -llvm*, -modernize-use-trailing-return-type'
+CheckOptions:
+    - key: readability-magic-numbers.IgnoredFloatingPointValues
+      value: '0.5;1.0;100.0'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,15 @@ project(eyebeam CXX)
 find_package(GTest CONFIG REQUIRED)
 find_package(benchmark CONFIG REQUIRED)
 
+add_library(enable_warnings INTERFACE)
+
+target_compile_options(enable_warnings INTERFACE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Werror> $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+)
+
+add_library(enable_cxx_17 INTERFACE)
+
+target_compile_features(enable_cxx_17 INTERFACE cxx_std_17)
+
 add_subdirectory(math)
 add_subdirectory(application)

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -6,10 +6,10 @@ add_library(application
 )
 
 target_link_libraries(application PUBLIC
+    enable_cxx_17
+    enable_warnings
     SDL2::SDL2
 )
-
-target_compile_features(application PUBLIC cxx_std_17)
 
 add_executable(eyebeam main.cpp)
 

--- a/application/sdl_application.cpp
+++ b/application/sdl_application.cpp
@@ -66,8 +66,8 @@ public:
     }
 
 private:
-    int m_argc;
-    char** m_argv;
+    [[maybe_unused]] int m_argc;
+    [[maybe_unused]] char** m_argv;
 
     std::unique_ptr<SDL_Window, WindowDeleter> m_window = nullptr;
 };

--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -6,6 +6,11 @@ add_library(math
     vector3.cpp
 )
 
+target_link_libraries(math PRIVATE
+    enable_cxx_17
+    enable_warnings
+)
+
 add_executable(mathtest
     constexpr_math_test.cpp
     point3_test.cpp
@@ -13,6 +18,8 @@ add_executable(mathtest
 )
 
 target_link_libraries(mathtest PRIVATE
+    enable_cxx_17
+    enable_warnings
     math
     GTest::gmock_main # See https://github.com/google/googletest/issues/2157#issuecomment-674361850
 )
@@ -25,6 +32,8 @@ add_executable(mathbench
 )
 
 target_link_libraries(mathbench PRIVATE
+    enable_cxx_17
+    enable_warnings
     math
     benchmark::benchmark
     benchmark::benchmark_main

--- a/math/components.h
+++ b/math/components.h
@@ -20,42 +20,48 @@ public:
     {
     }
 
-    constexpr auto x() const noexcept
+    Components(const Components&) = default;
+    Components(Components&&) = default;
+
+    Components& operator=(const Components&) = default;
+    Components& operator=(Components&&) = default;
+
+    [[nodiscard]] constexpr auto x() const noexcept
     {
         return m_components[0];
     }
 
-    constexpr auto y() const noexcept
+    [[nodiscard]] constexpr auto y() const noexcept
     {
         return m_components[1];
     }
 
-    constexpr auto z() const noexcept
+    [[nodiscard]] constexpr auto z() const noexcept
     {
         return m_components[2];
     }
 
-    constexpr auto w() const noexcept
+    [[nodiscard]] constexpr auto w() const noexcept
     {
         return m_components[3];
     }
 
-    auto& x() noexcept
+    [[nodiscard]] auto& x() noexcept
     {
         return m_components[0];
     }
 
-    auto& y() noexcept
+    [[nodiscard]] auto& y() noexcept
     {
         return m_components[1];
     }
 
-    auto& z() noexcept
+    [[nodiscard]] auto& z() noexcept
     {
         return m_components[2];
     }
 
-    auto& w() noexcept
+    [[nodiscard]] auto& w() noexcept
     {
         return m_components[3];
     }
@@ -67,11 +73,13 @@ private:
     std::array<float, 4> m_components;
 };
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr auto operator==(const Components& left, const Components& right) noexcept
 {
     return areEqual(left.x(), right.x()) && areEqual(left.y(), right.y()) && areEqual(left.z(), right.z());
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr auto operator!=(const Components& left, const Components& right) noexcept
 {
     return !(left == right);

--- a/math/constexpr_math.h
+++ b/math/constexpr_math.h
@@ -30,8 +30,8 @@ constexpr float sqrt(float x)
         return 0.0F;
     }
 
-    float guess = x;
-    float nextGuess = 0.5F * (guess + x / guess);
+    auto guess = x;
+    auto nextGuess = 0.5F * (guess + x / guess);
 
     while (abs(guess - nextGuess) > std::numeric_limits<float>::epsilon())
     {
@@ -42,9 +42,12 @@ constexpr float sqrt(float x)
     return guess;
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr bool areEqual(float left, float right) noexcept
 {
-    constexpr float epsilon = sqrt(std::numeric_limits<float>::epsilon());
+    static_assert(std::numeric_limits<float>::epsilon() > 0.0F);
+
+    constexpr auto epsilon = sqrt(std::numeric_limits<float>::epsilon());
     return abs(left - right) <= epsilon * std::max({1.0F, left, right});
 }
 

--- a/math/constexpr_math_benchmark.cpp
+++ b/math/constexpr_math_benchmark.cpp
@@ -16,10 +16,9 @@ void benchmarkStdAbs(benchmark::State& state)
 {
     const auto rand(RandomGenerator::generateRandomFloat());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        const auto result = std::abs(rand);
+        benchmark::DoNotOptimize(std::abs(rand));
     }
 }
 
@@ -27,10 +26,9 @@ void benchmarkStdSqrt(benchmark::State& state)
 {
     const auto rand(RandomGenerator::generateRandomFloat());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        const auto result = std::sqrt(rand);
+        benchmark::DoNotOptimize(std::sqrt(rand));
     }
 }
 
@@ -38,10 +36,9 @@ void benchmarkConstexprSqrt(benchmark::State& state)
 {
     const auto rand(RandomGenerator::generateRandomFloat());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        const auto result = sqrt(rand);
+        benchmark::DoNotOptimize(sqrt(rand));
     }
 }
 
@@ -49,10 +46,9 @@ void benchmarkConstexprAbs(benchmark::State& state)
 {
     const auto rand(RandomGenerator::generateRandomFloat());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        const auto result = abs(rand);
+        benchmark::DoNotOptimize(abs(rand));
     }
 }
 

--- a/math/constexpr_math_test.cpp
+++ b/math/constexpr_math_test.cpp
@@ -15,12 +15,12 @@ public:
     {
     }
 
-    constexpr auto input() const noexcept
+    [[nodiscard]] constexpr auto input() const noexcept
     {
         return m_input;
     }
 
-    constexpr auto result() const noexcept
+    [[nodiscard]] constexpr auto result() const noexcept
     {
         return m_result;
     }

--- a/math/point3.h
+++ b/math/point3.h
@@ -13,10 +13,7 @@ namespace eyebeam
 class Point3 : public Components
 {
 public:
-    constexpr Point3() noexcept
-    {
-    }
-
+    Point3() = default;
     explicit constexpr Point3(float x, float y, float z) noexcept : Components(x, y, z, 1.0F)
     {
     }

--- a/math/point3_benchmark.cpp
+++ b/math/point3_benchmark.cpp
@@ -13,9 +13,9 @@ void benchmarkPoint3OperatorPlusVectorOnRight(benchmark::State& state)
     const Point3 randLeft(RandomGenerator::generateRandomPoint3());
     const Vector3 randRight(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(randLeft + randRight);
+        benchmark::DoNotOptimize(randLeft + randRight);
     }
 }
 
@@ -24,9 +24,9 @@ void benchmarkPoint3OperatorPlusVectorOnLeft(benchmark::State& state)
     const Vector3 randLeft(RandomGenerator::generateRandomVector3());
     const Point3 randRight(RandomGenerator::generateRandomPoint3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(randLeft + randRight);
+        benchmark::DoNotOptimize(randLeft + randRight);
     }
 }
 
@@ -35,9 +35,9 @@ void benchmarkPoint3OperatorMinus(benchmark::State& state)
     const Point3 randLeft(RandomGenerator::generateRandomPoint3());
     const Point3 randRight(RandomGenerator::generateRandomPoint3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(randLeft - randRight);
+        benchmark::DoNotOptimize(randLeft - randRight);
     }
 }
 

--- a/math/vector3.h
+++ b/math/vector3.h
@@ -13,11 +13,8 @@ namespace eyebeam
 class Vector3 : public Components
 {
 public:
-    constexpr Vector3() noexcept
-    {
-    }
-
-    explicit constexpr Vector3(float x, float y, float z) noexcept : Components(x, y, z, 0.0f)
+    Vector3() = default;
+    explicit constexpr Vector3(float x, float y, float z) noexcept : Components(x, y, z, 0.0F)
     {
     }
 
@@ -47,7 +44,7 @@ public:
 
     auto& operator/=(float rhs) noexcept
     {
-        return *this *= (1.0f / rhs);
+        return *this *= (1.0F / rhs);
     }
 };
 

--- a/math/vector3_benchmark.cpp
+++ b/math/vector3_benchmark.cpp
@@ -15,9 +15,9 @@ void benchmarkVector3OperatorPlus(benchmark::State& state)
     Vector3 randLeft(RandomGenerator::generateRandomVector3());
     Vector3 randRight(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(randLeft + randRight);
+        benchmark::DoNotOptimize(randLeft + randRight);
     }
 }
 
@@ -26,9 +26,9 @@ void benchmarkVector3OperatorMinus(benchmark::State& state)
     Vector3 randLeft(RandomGenerator::generateRandomVector3());
     Vector3 randRight(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(randLeft - randRight);
+        benchmark::DoNotOptimize(randLeft - randRight);
     }
 }
 
@@ -37,9 +37,9 @@ void benchmarkVector3OperatorMultiplyScaleOnRight(benchmark::State& state)
     Vector3 randLeft(RandomGenerator::generateRandomVector3());
     float scale = RandomGenerator::generateRandomFloat();
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(randLeft * scale);
+        benchmark::DoNotOptimize(randLeft * scale);
     }
 }
 
@@ -48,9 +48,9 @@ void benchmarkVector3OperatorMultiplyScaleOnLeft(benchmark::State& state)
     Vector3 randRight(RandomGenerator::generateRandomVector3());
     float scale = RandomGenerator::generateRandomFloat();
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(scale * randRight);
+        benchmark::DoNotOptimize(scale * randRight);
     }
 }
 
@@ -59,9 +59,9 @@ void benchmarkVector3OperatorDivide(benchmark::State& state)
     Vector3 randLeft(RandomGenerator::generateRandomVector3());
     float scale = RandomGenerator::generateRandomFloat();
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(randLeft / scale);
+        benchmark::DoNotOptimize(randLeft / scale);
     }
 }
 
@@ -69,9 +69,9 @@ void benchmarkVector3Negation(benchmark::State& state)
 {
     Vector3 rand(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result(-rand);
+        benchmark::DoNotOptimize(-rand);
     }
 }
 
@@ -80,10 +80,9 @@ void benchmarkVector3DotProduct(benchmark::State& state)
     Vector3 randLeft(RandomGenerator::generateRandomVector3());
     Vector3 randRight(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        const auto result = dot(randLeft, randRight);
+        benchmark::DoNotOptimize(dot(randLeft, randRight));
     }
 }
 
@@ -92,9 +91,9 @@ void benchmarkVector3CrossProduct(benchmark::State& state)
     Vector3 randLeft(RandomGenerator::generateRandomVector3());
     Vector3 randRight(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result = cross(randLeft, randRight);
+        benchmark::DoNotOptimize(cross(randLeft, randRight));
     }
 }
 
@@ -102,10 +101,9 @@ void benchmarkVector3LengthSquared(benchmark::State& state)
 {
     Vector3 rand(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        const auto result = lengthSquared(rand);
+        benchmark::DoNotOptimize(lengthSquared(rand));
     }
 }
 
@@ -113,10 +111,9 @@ void benchmarkVector3Length(benchmark::State& state)
 {
     Vector3 rand(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        const auto result = length(rand);
+        benchmark::DoNotOptimize(length(rand));
     }
 }
 
@@ -124,9 +121,9 @@ void benchmarkVector3Norm(benchmark::State& state)
 {
     Vector3 rand(RandomGenerator::generateRandomVector3());
 
-    for (auto s : state)
+    for ([[maybe_unused]] auto s : state)
     {
-        const auto result = norm(rand);
+        benchmark::DoNotOptimize(norm(rand));
     }
 }
 


### PR DESCRIPTION
This change is a mix of warning fixes from Clang, clang-tidy fixes, and three nolints.

The nolints were added because sqrt() is being used by a noexcept function to take the
square root of a positive constant. Because sqrt() only throws when receiving a negative
input, the tool is generating a false positive.