### PR TITLE
Align components class to 16 bytes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,3 +2,5 @@ Checks: '*, -abseil*, -android*, -cppcoreguidelines-avoid-magic-numbers, -fuchsi
 CheckOptions:
     - key: readability-magic-numbers.IgnoredFloatingPointValues
       value: '0.5;1.0;100.0'
+    - key: readability-magic-numbers.IgnoredIntegerValues
+      value: '1;2;3;4;16'

--- a/math/components.h
+++ b/math/components.h
@@ -9,7 +9,7 @@
 namespace eyebeam
 {
 
-class Components
+class alignas(16) Components
 {
 public:
     constexpr Components() noexcept : Components(0.0F, 0.0F, 0.0F, 0.0F)


### PR DESCRIPTION
This enables clang's assembly generation to generate aligned moves.

No noticable change in the benchmarks, but it didn't hurt either.