### PR TITLE
Rollup local changes to continue work on this project

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,13 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${command:cmake.launchTargetPath}",
-            "args": ["./data/scenes/scene.json"],
+            "args": [
+                "./data/scenes/scene.json"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "externalConsole": true,
+            "console": "newExternalWindow",
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,20 @@
         "xutility": "cpp",
         "chrono": "cpp",
         "ratio": "cpp",
-        "thread": "cpp"
+        "thread": "cpp",
+        "bit": "cpp",
+        "charconv": "cpp",
+        "clocale": "cpp",
+        "filesystem": "cpp",
+        "format": "cpp",
+        "forward_list": "cpp",
+        "fstream": "cpp",
+        "locale": "cpp",
+        "numeric": "cpp",
+        "optional": "cpp",
+        "stop_token": "cpp",
+        "valarray": "cpp",
+        "xlocbuf": "cpp",
+        "xlocmes": "cpp"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,17 @@ add_library(enable_cxx_17 INTERFACE)
 
 target_compile_features(enable_cxx_17 INTERFACE cxx_std_17)
 
+add_library(cxx_base_options INTERFACE)
+
+target_compile_options(cxx_base_options INTERFACE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:> $<$<CXX_COMPILER_ID:MSVC>:/Incremental:NO>
+)
+
+target_link_libraries(cxx_base_options INTERFACE
+    enable_cxx_17
+    enable_warnings
+)
+
 add_subdirectory(math)
 add_subdirectory(scene)
 add_subdirectory(application)

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -6,8 +6,7 @@ add_library(application
 )
 
 target_link_libraries(application PUBLIC
-    enable_cxx_17
-    enable_warnings
+    cxx_base_options
     scene
     SDL2::SDL2
 )

--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -14,8 +14,7 @@ add_library(math
 )
 
 target_link_libraries(math PRIVATE
-    enable_cxx_17
-    enable_warnings
+    cxx_base_options
 )
 
 target_include_directories(math PUBLIC
@@ -36,8 +35,7 @@ add_executable(mathtest
 )
 
 target_link_libraries(mathtest PRIVATE
-    enable_cxx_17
-    enable_warnings
+    cxx_base_options
     math
     GTest::gmock_main # See https://github.com/google/googletest/issues/2157#issuecomment-674361850
 )
@@ -54,8 +52,7 @@ add_executable(mathbench
 )
 
 target_link_libraries(mathbench PRIVATE
-    enable_cxx_17
-    enable_warnings
+    cxx_base_options
     math
     benchmark::benchmark_main
     benchmark::benchmark

--- a/math/components.h
+++ b/math/components.h
@@ -9,6 +9,9 @@
 namespace eyebeam
 {
 
+template <size_t Size>
+using UnalignedComponentStorage = std::array<float, Size>;
+
 class alignas(16) Components
 {
 public:

--- a/math/intersection_info.cpp
+++ b/math/intersection_info.cpp
@@ -1,11 +1,22 @@
 #include "intersection_info.h"
 
+#include "normal3.h"
+#include "point3.h"
+#include "quadratic_solver.h"
+
 #include <limits>
 
 namespace eyebeam
 {
 
 IntersectionInfo::IntersectionInfo() : IntersectionInfo(Point3(), Normal3(), std::numeric_limits<float>::max())
+{
+}
+
+IntersectionInfo::IntersectionInfo(const Point3& intersection, const Normal3& normal, float time)
+    : m_intersectionPoint(intersection)
+    , m_normal(norm(normal))
+    , m_time(time)
 {
 }
 
@@ -22,6 +33,16 @@ void IntersectionInfo::updateWithNewIntersection(const IntersectionInfo& newData
 bool isIntersecting(const IntersectionInfo& intersection) noexcept
 {
     return intersection.getTime() < std::numeric_limits<float>::max();
+}
+
+float getEarliestViableIntersection(const QuadraticRoots& t) noexcept
+{
+    if (t[0] > 0.0F)
+    {
+        return t[0];
+    }
+
+    return t[1];
 }
 
 } // namespace eyebeam

--- a/math/intersection_info.h
+++ b/math/intersection_info.h
@@ -3,6 +3,7 @@
 
 #include "normal3.h"
 #include "point3.h"
+#include "quadratic_solver.h"
 
 namespace eyebeam
 {
@@ -11,13 +12,7 @@ class IntersectionInfo
 {
 public:
     IntersectionInfo();
-
-    IntersectionInfo(const Point3& intersection, const Normal3& normal, float time)
-        : m_intersectionPoint(intersection)
-        , m_normal(norm(normal))
-        , m_time(time)
-    {
-    }
+    IntersectionInfo(const Point3& intersection, const Normal3& normal, float time);
 
     [[nodiscard]] Normal3 getNormal() const noexcept
     {
@@ -42,6 +37,7 @@ private:
     float m_time;
 };
 
+float getEarliestViableIntersection(const QuadraticRoots& t) noexcept;
 bool isIntersecting(const IntersectionInfo& intersection) noexcept;
 
 } // namespace eyebeam

--- a/math/matrix4.h
+++ b/math/matrix4.h
@@ -32,7 +32,7 @@ void scaleRow(std::array<float, 16>& toInvert, std::array<float, 16>& inverse, s
 
 } // namespace impl
 
-using UnalignedMatrixStorage = std::array<float, 16>;
+using UnalignedMatrixStorage = UnalignedComponentStorage<16>;
 
 struct alignas(16) AlignedMatrixStorage
 {
@@ -73,6 +73,11 @@ public:
         float e33) noexcept
         : Matrix4(AlignedMatrixStorage{e00, e01, e02, e03, e10, e11, e12, e13, e20, e21, e22, e23, e30, e31, e32, e33})
     {
+    }
+
+    [[nodiscard]] constexpr UnalignedMatrixStorage getUnaligned() const noexcept
+    {
+        return m_elements;
     }
 
     [[nodiscard]] constexpr static Matrix4 buildIdentity() noexcept

--- a/math/point3.h
+++ b/math/point3.h
@@ -22,7 +22,8 @@ public:
     {
     }
 
-    explicit constexpr Point3(const std::array<float, 3>& values) noexcept : Point3(values[0], values[1], values[2])
+    explicit constexpr Point3(const UnalignedComponentStorage<3>& values) noexcept
+        : Point3(values[0], values[1], values[2])
     {
     }
 

--- a/math/transform.h
+++ b/math/transform.h
@@ -8,6 +8,7 @@
 #include "vector3.h"
 
 #include <iosfwd>
+#include <utility>
 
 namespace eyebeam
 {
@@ -15,6 +16,8 @@ namespace eyebeam
 class Normal3;
 class Point3;
 class Ray3;
+
+using UnalignedTransformStorage = std::pair<UnalignedMatrixStorage, UnalignedMatrixStorage>;
 
 class Transform
 {
@@ -24,7 +27,23 @@ public:
     {
     }
 
+    constexpr Transform(const UnalignedMatrixStorage& matrix, const UnalignedMatrixStorage& inverse)
+        : m_matrix(matrix)
+        , m_inverse(inverse)
+    {
+    }
+
+    constexpr Transform(const UnalignedTransformStorage& transform) : Transform(transform.first, transform.second)
+    {
+    }
+
+    explicit Transform(const UnalignedMatrixStorage& elements);
     explicit Transform(const AlignedMatrixStorage& elements);
+
+    UnalignedTransformStorage getTransformUnaligned() const noexcept
+    {
+        return std::make_pair(m_matrix.getUnaligned(), m_inverse.getUnaligned());
+    }
 
     [[nodiscard]] constexpr auto inverse() const noexcept
     {

--- a/math/vector3.h
+++ b/math/vector3.h
@@ -18,7 +18,8 @@ public:
     {
     }
 
-    explicit constexpr Vector3(const std::array<float, 3>& values) noexcept : Vector3(values[0], values[1], values[2])
+    explicit constexpr Vector3(const UnalignedComponentStorage<3>& values) noexcept
+        : Vector3(values[0], values[1], values[2])
     {
     }
 

--- a/scene/CMakeLists.txt
+++ b/scene/CMakeLists.txt
@@ -12,8 +12,7 @@ target_include_directories(scene PUBLIC
 )
 
 target_link_libraries(scene PRIVATE
-    enable_cxx_17
-    enable_warnings
+    cxx_base_options
 )
 
 target_link_libraries(scene PUBLIC


### PR DESCRIPTION
- Fix a Visual Studio warning related to alignment padding during scene construction
- Refactor CMakeLists.txt to provide a C++ base options library that enables C++17 and warnings together
- Add some helpers to intersection_info to retrieve the earliest quadratic intersection time
- Update the VSCode launch and settings JSON files (automatic)